### PR TITLE
[FEAT] Ajout de la gestion des timeouts/retries

### DIFF
--- a/ingestor/scraper/api/utils/robust_http.py
+++ b/ingestor/scraper/api/utils/robust_http.py
@@ -1,0 +1,33 @@
+import os
+import time
+import logging
+import requests
+
+HTTP_TIMEOUT = int(os.getenv("HTTP_TIMEOUT", 10))
+HTTP_MAX_BACKOFF = int(os.getenv("HTTP_MAX_BACKOFF", 300))
+HTTP_RETRY_BASE = int(os.getenv("HTTP_RETRY_BASE", 5))
+
+RETRY_STATUS = {429} | set(range(500, 600))
+
+def robust_request(method, url, **kwargs):
+    backoff = HTTP_RETRY_BASE
+    while True:
+        try:
+            resp = requests.request(method, url, timeout=HTTP_TIMEOUT, **kwargs)
+            if resp.status_code in RETRY_STATUS:
+                logging.warning(f"HTTP {resp.status_code} on {url}, retrying in {backoff}s")
+                time.sleep(backoff)
+                backoff = min(backoff * 3, HTTP_MAX_BACKOFF)
+                continue
+            # Succès
+            if backoff != HTTP_RETRY_BASE:
+                logging.info(f"Recovered: {url}")
+            return resp
+        except (requests.Timeout, requests.ConnectionError) as e:
+            logging.warning(f"Network error on {url}: {e}, retrying in {backoff}s")
+            time.sleep(backoff)
+            backoff = min(backoff * 3, HTTP_MAX_BACKOFF)
+        except Exception as e:
+            logging.error(f"Fatal error on {url}: {e}")
+            raise
+    # Remise à zéro du backoff si succès (déjà géré par le return)

--- a/ingestor/scraper/component/scraper/scraper.py
+++ b/ingestor/scraper/component/scraper/scraper.py
@@ -4,6 +4,7 @@ from typing import Dict, Any, List
 
 from bs4 import BeautifulSoup
 from requests_html import HTMLSession
+from ingestor.scraper.api.utils.robust_http import robust_request
 
 # Dictionnaire des parsers
 SITE_PARSERS = {}
@@ -139,13 +140,15 @@ def run_all() -> List[Dict[str, Any]]:
         if parser_func:
             print(f"Parsing {url} with {parser_func.__name__}")
             try:
-                r = session.get(url)
-
+                r = robust_request("GET", url)
                 if domain_key in ["coinmarketcap.com", "binance.com"]:
                     data = r.json()
                     results = parser_func(url, data)
                 else:
-                    soup = BeautifulSoup(r.html.html, "lxml")
+                    # Pour requests_html, on doit charger le HTML dans l'objet session
+                    html_obj = session.get(url)
+                    html_obj.html.html = r.text
+                    soup = BeautifulSoup(html_obj.html.html, "lxml")
                     results = parser_func(url, soup)
 
                 print(f"{len(results)} items parsed from {domain_key}")


### PR DESCRIPTION
Ajout de la gestion des timeouts et des retries dans les requêtes HTTP pour rendre le scraper plus robuste aux pannes réseau temporaires. Modification du scraper pour utiliser ces nouvelles fonctionnalités

Attention, il faut rajouter les champs suivant dans le .env : 
HTTP_TIMEOUT=10
HTTP_MAX_BACKOFF=300
HTTP_RETRY_BASE=5